### PR TITLE
Update README with additional documentation about Allow Execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Driver Packager requires:
 >   * **-h, --help**: show help message and exit
 >   * **-v, --verbose**: Enable verbose
 >   * **-u, --unzip**: Unzip the c4z in the target location
->   * **-ae, --allowexecute**: Allow Execute in Lua Command window even for encrypted driver (adds C4:AllowExecute(true) to Lua source)
+>   * **-ae, --allowexecute**: Allow Execute in Lua Command window even for encrypted driver (adds C4:AllowExecute(true) to Lua source). Also enables DevLog (adds gIsDevelopmentVersionOfDriver = true).
 
 ## Using Driver Packager in Github Actions
 


### PR DESCRIPTION
The --allowexecute will not only append C4 API call but also set gIsDevelopmentVersionOfDriver to true, which enables DevLog function to print.