### PR TITLE
Fix python version for github actions to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 
 COPY entrypoint.sh /entrypoint.sh
 COPY ./dp3 /app/dp3


### PR DESCRIPTION
imp module is removed in the latest python3 release (3.12).
https://web.archive.org/web/20230822114549/https://docs.python.org/3/library/imp.html